### PR TITLE
ignorowanie pliku DbConfig.java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/
+src/projekt/DbConfig.java


### PR DESCRIPTION
plik DbConfig.java ma być tworzony z pliku DbConfig.java.sample
